### PR TITLE
Fix Kotlin tuple example

### DIFF
--- a/code/tuple-return.kt
+++ b/code/tuple-return.kt
@@ -1,3 +1,7 @@
+fun getGasPrices() = 3.59 to 3.69 to 3.79
+
+// Using data classes for more complex data:
+
 data class GasPrices(val a: Double, val b: Double,
      val c: Double)
-fun getGasPrices() = GasPrices(3.59, 3.69, 3.79)
+fun getGasPriceData() = GasPrices(3.59, 3.69, 3.79)


### PR DESCRIPTION
# Why?
* The tuples example used data classes instead of tuples/`Pair`s.

# What changed?
* Used the `to` operator function in the `tuple` example.