### PR TITLE
typo from upstream

### DIFF
--- a/cirru/index.cirru
+++ b/cirru/index.cirru
@@ -41,7 +41,7 @@ html
         .card (.lang Kotlin) $ pre.code $ code (@insert ../code/inclusive-range-operator.kt)
 
     .section
-      .title BASICS
+      .title COLLECTIONS
       .case (.name "Arrays") $ .pair
         .card (.lang Swift) $ pre.code $ code (@insert ../code/arrays.swift)
         .card (.lang Kotlin) $ pre.code $ code (@insert ../code/arrays.kt)


### PR DESCRIPTION
Fixed the typo. Based on https://leverich.github.io/swiftislikescala/

And... well, I'm from upstream and after reading your code I updated mine, mainly to remove the deprecated `mission.coffee` thing. I won't send a PR of that refactoring since it would cause conflicts.

I guess you may have run into problems since cirru-html is no longer maintained. Ping me on [Twitter](https://twitter.com/jiyinyiyong) if necessary.