### PR TITLE
Update tuple example

### DIFF
--- a/code/tuple-return.kt
+++ b/code/tuple-return.kt
@@ -1,3 +1,1 @@
-data class GasPrices(val a: Double, val b: Double,
-     val c: Double)
-fun getGasPrices() = GasPrices(3.59, 3.69, 3.79)
+fun getGasPrices() = 3.59 to 3.69 to 3.79


### PR DESCRIPTION
The tuple example in Kotlin was creating a new data class whereas the Swift example not. 
To align these, In Kotlin as well, you have `Pair` and `Triple` to do the same. This, I think, makes the examples closer.