### PR TITLE
Add missing space

### DIFF
--- a/code/functions.swift
+++ b/code/functions.swift
@@ -1,4 +1,4 @@
-func greet(_ name: String,_ day: String) -> String {
+func greet(_ name: String, _ day: String) -> String {
     return "Hello \(name), today is \(day)."
 }
 greet("Bob", "Tuesday")


### PR DESCRIPTION
Swiftlint rule recommend to have ` ` between parameters.